### PR TITLE
User story 3

### DIFF
--- a/app/controllers/api/v1/backgrounds_controller.rb
+++ b/app/controllers/api/v1/backgrounds_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::BackgroundsController < ApplicationController
       image = UnsplashImageFacade.find_image(params[:location])
       render json: BackgroundSerializer.format_background(image)
     else
-      render json: { error: 'bad request' }, status: 400
+      render json: { data: { message: 'bad request' } }, status: 400
     end
   end
 end

--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::ForecastController < ApplicationController
     if params[:location]
       @location = MapQuestFacade.find_coordinates(params[:location])
     else
-      render json: { error: 'bad request' }, status: 404
+      render json: { data: { message: 'bad request'} }, status: 400
     end
   end
 end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::SessionsController < ApplicationController
+
+  def create
+    user = User.find_by(email: params[:email])
+    if user && user.authenticate(params[:password])
+      session[:user_id] = user.id
+      render json: UserSerializer.new_user_data(user), status: 201
+    else
+      render json: { data: { message: 'Invalid credentials'} }, status: 424
+    end
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,11 +3,11 @@ class Api::V1::UsersController < ApplicationController
   def create
     user = User.new(user_params)
     if params[:email].nil? || params[:password].nil? || params[:password_confirmation].nil?
-      render json: { error: 'All fields must be filled in'}, status: :bad_request
+      render json: { data: {message: 'All fields must be filled in'} }, status: :bad_request
     elsif User.find_by(email: user.email)
-      render json: { error: 'Email already in use' }, status: :bad_request
+      render json: { data: {message: 'Email already in use'} }, status: :bad_request
     elsif params[:password] != params[:password_confirmation]
-      render json: { error: 'Passwords must match' }, status: :bad_request
+      render json: { data: {message: 'Passwords must match'} }, status: :bad_request
     elsif user.save
       user.api_key = SecureRandom.hex
       render json: UserSerializer.new_user_data(user), status: 201

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
       get '/forecast', to: 'forecast#index'
       get '/backgrounds', to: 'backgrounds#index'
       post '/users', to: 'users#create'
+      post '/sessions', to: 'sessions#create'
     end
   end
 end

--- a/spec/requests/api/v1/background_image_request_spec.rb
+++ b/spec/requests/api/v1/background_image_request_spec.rb
@@ -24,5 +24,9 @@ RSpec.describe 'the background image endpoint' do
 
     expect(response).to_not be_successful
     expect(response.status).to eq(400)
+
+    error = JSON.parse(response.body, symbolize_names: true)
+
+    expect(error[:data][:message]).to eq('bad request')
   end
 end

--- a/spec/requests/api/v1/forecast_requests_spec.rb
+++ b/spec/requests/api/v1/forecast_requests_spec.rb
@@ -79,6 +79,10 @@ RSpec.describe 'the forecast endpoint' do
   it 'returns an error when given invalid params', :vcr do
     get '/api/v1/forecast', params: { weather: "richmond,va" }
 
-    expect(response.status).to eq(404)
+    expect(response.status).to eq(400)
+
+    error = JSON.parse(response.body, symbolize_names: true)
+
+    expect(error[:data][:message]).to eq('bad request')
   end
 end

--- a/spec/requests/api/v1/session_spec.rb
+++ b/spec/requests/api/v1/session_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'the session endpoint' do
     expect(response.status).to eq(201)
 
     user = JSON.parse(response.body, symbolize_names: true)
-    
+
 
     expect(user).to be_a Hash
     expect(user).to have_key(:data)
@@ -23,5 +23,19 @@ RSpec.describe 'the session endpoint' do
     expect(user[:data][:attributes][:email]).to eq(user_1.email)
     expect(user[:data][:attributes]).to have_key(:api_key)
     expect(user[:data][:attributes][:api_key]).to eq(user_1.api_key)
+  end
+
+  it 'sad path returns appropriate message if given bad credentials' do
+    user_1 = User.create!(email: "test_1@testmail.test", password: "supersecret", password_confirmation: "supersecret")
+
+    bad_login_info = { "email": "test_1@testmail.test", "password": "notsupersecret"}
+
+    post '/api/v1/sessions', params: bad_login_info
+    expect(response.status).to eq(424)
+
+    error = JSON.parse(response.body, symbolize_names: true)
+    
+    expect(error[:data][:message]).to eq('Invalid credentials')
+
   end
 end

--- a/spec/requests/api/v1/session_spec.rb
+++ b/spec/requests/api/v1/session_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'the session endpoint' do
+  it 'happy path creates a session' do
+    user_1 = User.create!(email: "test_1@testmail.test", password: "supersecret", password_confirmation: "supersecret")
+
+    login_info = { "email": "test_1@testmail.test", "password": "supersecret"}
+
+    post '/api/v1/sessions', params: login_info
+    expect(response.status).to eq(201)
+
+    user = JSON.parse(response.body, symbolize_names: true)
+    
+
+    expect(user).to be_a Hash
+    expect(user).to have_key(:data)
+    expect(user[:data]).to have_key(:type)
+    expect(user[:data][:type]).to eq('user')
+    expect(user[:data]).to have_key(:id)
+    expect(user[:data][:id]).to eq(user_1.id)
+    expect(user[:data]).to have_key(:attributes)
+    expect(user[:data][:attributes]).to have_key(:email)
+    expect(user[:data][:attributes][:email]).to eq(user_1.email)
+    expect(user[:data][:attributes]).to have_key(:api_key)
+    expect(user[:data][:attributes][:api_key]).to eq(user_1.api_key)
+  end
+end

--- a/spec/requests/api/v1/user_requests_spec.rb
+++ b/spec/requests/api/v1/user_requests_spec.rb
@@ -28,8 +28,12 @@ RSpec.describe 'the user request' do
       "password": "pass",
       "password_confirmation": "password"
     }
-    post '/api/v1/users', params: JSON.generate(data)
+    post '/api/v1/users', params: data
 
     expect(response.status).to eq(400)
+
+    error = JSON.parse(response.body, symbolize_names: true)
+
+    expect(error[:data][:message]).to eq('Passwords must match')
   end
 end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'the user serializer' do
+
+  it 'serializes user info into json' do
+    user = User.create!(email: 'testemail@test.test', password_digest: 'password123')
+    json = JSON.parse(UserSerializer.new_user_data(user).to_json, symbolize_names: true)
+
+    expect(json).to be_a Hash
+    expect(json).to have_key(:data)
+    expect(json[:data]).to have_key(:type)
+    expect(json[:data][:type]).to eq('user')
+    expect(json[:data]).to have_key(:id)
+    expect(json[:data][:id]).to eq(user.id)
+    expect(json[:data]).to have_key(:attributes)
+    expect(json[:data][:attributes]).to have_key(:email)
+    expect(json[:data][:attributes][:email]).to eq(user.email)
+    expect(json[:data][:attributes]).to have_key(:api_key)
+    expect(json[:data][:attributes][:api_key]).to eq(user.api_key)
+  end
+end


### PR DESCRIPTION
This US covers the functionality of implementing an endpoint that will enable users to login. It exposes the endpoint '/api/v1/sessions' with a POST action, goes through authentication with bcrypt, and generates a new user through the User serializer. Sad path provides a generic 'invalid credentials' message in the body of the JSON response so as not to give any potential malicious users an advantage. Creation of a user also returns an api key. 